### PR TITLE
Support for Lead Actors inside the interpreter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ install:
   - sudo apt-get install luarocks
   - chmod +x travis.sh
   - ./travis.sh
-  - sudo luarocks install busted
-  
-script: make && make DIALOGUE_HEADLESS=true && make check
+      - sudo luarocks install busted
+      
+script: make && make DIALOGUE_HEADLESS=true && make DIALOGUE_HEADLESS=true check
 
 notifications:
   recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
   - ./travis.sh
       - sudo luarocks install busted
       
+before_script: which busted
 script: make && make DIALOGUE_HEADLESS=true check
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - ./travis.sh
       - sudo luarocks install busted
       
-script: make && make DIALOGUE_HEADLESS=true && make DIALOGUE_HEADLESS=true check
+script: make && make DIALOGUE_HEADLESS=true check
 
 notifications:
   recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ install:
   - sudo apt-get install luarocks
   - chmod +x travis.sh
   - ./travis.sh
-      - sudo luarocks install busted
+  - sudo luarocks install busted
       
-before_script: which busted
 script: make && make DIALOGUE_HEADLESS=true check
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ install:
   - ./travis.sh
   - sudo luarocks install busted
   
-before_script: export DIALOGUE_HEADLESS=true
-script: make build && make check
+script: make && make DIALOGUE_HEADLESS=true && make check
 
 notifications:
   recipients:

--- a/Graphics.lua
+++ b/Graphics.lua
@@ -6,28 +6,28 @@ function Graphics.new (x, y)
    local table = {}
    setmetatable(table, Graphics)
    table.window = Window.new(400, 600)
-   table.coordinates = {x, y} or {0, 0}
+   table.to_draw = {}
    return table
 end
 
-function Graphics:draw ()
+function Graphics:draw (definition)
+    table.insert(self.to_draw, definition)
+end
+
+function Graphics:render ()
     self.window:clear()
     self.window:set_color(128, 128, 128, 255)
-    self.window:draw(0, 0, 50, 50)
-end
-
-function Graphics:move (x, y)
-    self.coordinates[1] = self.coordinates[1] + x
-    self.coordinates[2] = self.coordinates[2] + y
-end
-
-function Graphics:update ()
-    if self.window:per_second(1) then
-        self.window:clear()
-        self.window:set_color(128, 128, 128, 255)
-        self.window:draw(self.coordinates[1], self.coordinates[2], 50, 50)
-        self.window:render()
+    for i, definition in ipairs(self.to_draw) do
+        self.window:draw(unpack(definition))
     end
+    self.window:render()
+end
+
+function Graphics:main ()
+    --if self.window:per_second(1) then
+    --    io.write("second\n")
+    --end
+    self:render()
 end
 
 return Graphics

--- a/Graphics.lua
+++ b/Graphics.lua
@@ -22,10 +22,12 @@ function Graphics:move (x, y)
 end
 
 function Graphics:update ()
-    self.window:clear()
-    self.window:set_color(128, 128, 128, 255)
-    self.window:draw(self.coordinates[1], self.coordinates[2], 50, 50)
-    self.window:render()
+    if self.window:per_second(1) then
+        self.window:clear()
+        self.window:set_color(128, 128, 128, 255)
+        self.window:draw(self.coordinates[1], self.coordinates[2], 50, 50)
+        self.window:render()
+    end
 end
 
 return Graphics

--- a/Makefile
+++ b/Makefile
@@ -30,16 +30,14 @@ ifeq ($(UNAME), Darwin)
 endif
 
 all: clean build
+check: clean build test
 
 build: $(SOURCES)
 	$(CC) -g $(CFLAGS) $(SOFLAGS) -o $(MODULE) $^ $(LDFLAGS)
 
-check:
+test:
 	cp $(MODULE) spec/
 	cd spec/ && busted spec.lua
-
-test:
-	valgrind --leak-check=full -v lua -i stage.lua
 
 clean:
 	rm -f $(MODULE) src/*o

--- a/spec/spec.lua
+++ b/spec/spec.lua
@@ -95,11 +95,10 @@ describe("An Actor", function()
             local errfn = function()
                 actor:lead()
             end
-
             assert.has_error(errfn, "Lead Actor table only exists in Main thread!")
         end)
 
-        it("is created from a regular actor, which closes its thread", function()
+        it("can be created from a regular actor, closing its thread", function()
             _G.__main_thread = 1
             actor:lead()
             actor:send{"move", 2, 2}
@@ -107,7 +106,14 @@ describe("An Actor", function()
             assert.are.same({0, 0}, actor:scripts()[1]:probe("coordinates"))
         end)
 
+        it("can be created Lead-Actor-only by passing in an option", function()
+            actor = nil
+            actor = Dialogue.Actor.new{ "Lead", {"draw", 250, 250} }
+            assert.are.same({250, 250}, actor:scripts()[1]:probe("coordinates"))
+        end)
+
         it("has to process its messages manually", function()
+            actor:send{"move", -235, -235}
             actor:receive()
             assert.are.same({15, 15}, actor:scripts()[1]:probe("coordinates"))
         end)
@@ -125,7 +131,7 @@ describe("A Dialogue", function()
         { {"weapon", "Crown", "North"} },
         {
             { 
-                { {"draw", 2, 4} },
+                { "Lead", {"draw", 2, 4} },
                 {}
             },
             { 
@@ -202,6 +208,10 @@ describe("A Dialogue", function()
         assert.is_equal(audience[6]:__tostring(), e:__tostring())
     end)
 
+    it("can be created from a mix of Lead and regular Actors", function()
+        assert.are.same(a:scripts()[1]:probe("coordinates"), {2, 4})
+    end)
+
     it("allows for Actors to send message by via Tone yell", function()
         dialogue:yell{"attack"}
         os.execute("sleep " .. tonumber(0.5))
@@ -222,6 +232,7 @@ describe("A Dialogue", function()
         b:say{"move", 1, 1}
         os.execute("sleep " .. tonumber(0.5))
 
+        a:receive()
         assert.are.same(a:scripts()[1]:probe("coordinates"), {3, 5})
         assert.are.same(b:scripts()[1]:probe("coordinates"), {401, 201})
         assert.are.same(e:scripts()[1]:probe("coordinates"), {21, 7})
@@ -246,6 +257,7 @@ describe("A Dialogue", function()
 
         dialogue:yell{"walk"}
         os.execute("sleep " .. tonumber(0.5))
+        a:receive()
         assert.are.same(a:scripts()[1]:probe("coordinates"), {5, 7})
         assert.are.same(b:scripts()[1]:probe("coordinates"), {404, 204})
         assert.are.same(e:scripts()[1]:probe("coordinates"), {22, 8})

--- a/src/actor.c
+++ b/src/actor.c
@@ -124,13 +124,11 @@ actor_assign_lead (Actor *actor, lua_State *L)
     int top = actor_lead_table(L);
     int len = luaL_len(L, top);
 
-    printf("len (%d) before %p\n", len, actor);
-
     lua_rawgeti(L, LUA_REGISTRYINDEX, actor->ref);
     lua_rawseti(L, top, len + 1);
+
     lua_pop(L, 1);
 
-    printf("len (%d) after %p\n", luaL_len(L, top), actor);
 }
 
 /*
@@ -172,6 +170,10 @@ lua_actor_new (lua_State *L)
     actor = lua_newuserdata(L, sizeof(*actor));
     luaL_getmetatable(L, ACTOR_LIB);
     lua_setmetatable(L, -2);
+
+    /* Create a reference so it doesn't GC */
+    actor->ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    lua_rawgeti(L, LUA_REGISTRYINDEX, actor->ref);
 
     actor->parent = NULL;
     actor->next = NULL;

--- a/src/actor.h
+++ b/src/actor.h
@@ -26,7 +26,7 @@ typedef struct Actor {
     Action action;
 
     short int on;
-    short int manual_call;
+    short int is_lead;
 
     /* Tree nav: go up, horizontally, and down the tree */
     struct Actor *parent;

--- a/src/actor.h
+++ b/src/actor.h
@@ -47,9 +47,10 @@ typedef struct Actor {
 
 /*
  * Leave the Lead Actor table on top of the stack. Creates it if it doesn't
- * exist. Will throw an error if not called on Main thread.
+ * exist. Will throw an error if not called on Main thread. Returns its
+ * position on the stack.
  */
-void
+int
 actor_lead_table (lua_State *L);
 
 /*

--- a/src/dialogue.c
+++ b/src/dialogue.c
@@ -36,8 +36,7 @@ lua_dialogue_new (lua_State *L)
     utils_push_table_head(L, dialogue_table);
     lua_call(L, 1, 1);
     actor = lua_check_actor(L, -1);
-    actor->ref = luaL_ref(L, LUA_REGISTRYINDEX);
-    lua_pop(L, 2);
+    lua_pop(L, 3);
 
     /*
      * The recursion relies on sending the first created Actor (the head) to
@@ -63,10 +62,9 @@ lua_dialogue_new (lua_State *L)
         lua_call(L, 2, 1);
 
         child = lua_check_actor(L, -1);
-        child->ref = luaL_ref(L, LUA_REGISTRYINDEX);
         actor_add_child(actor, child);
 
-        lua_pop(L, 2); /* key & Dialogue */
+        lua_pop(L, 3); /* chidl, key, Dialogue */
     }
     lua_pop(L, 1);
 

--- a/src/mailbox.c
+++ b/src/mailbox.c
@@ -95,22 +95,14 @@ mailbox_push_next_envelope (Mailbox *mailbox)
     int message_ref;
     lua_State *B = mailbox->L;
 
-    /* remove like queue LIFO */
-    lua_getglobal(B, "table");
-    lua_getfield(B, -1, "remove");
     lua_getglobal(B, "__envelopes");
-    lua_pushinteger(B, 1);
-    lua_call(B, 2, 1);
-
-    /* move the 'table' on top to pop */
-    lua_insert(B, lua_gettop(B) - 1);
-    lua_pop(B, 1);
+    utils_pop_table_head(B, lua_gettop(B));
 
     /* get all the relevant info before popping and gcing envelope */
     envelope = lua_check_envelope(B, -1);
     message_ref = envelope->message_ref;
     author = envelope->author;
-    lua_pop(B, 1);
+    lua_pop(B, 2); /* envelope & envelope table */
 
     /* finally push table and unref it */
     lua_rawgeti(B, LUA_REGISTRYINDEX, message_ref);

--- a/src/main.c
+++ b/src/main.c
@@ -57,20 +57,23 @@ main (int argc, char **argv)
     luaL_requiref(L, "Dialogue", luaopen_Dialogue, 1);
     lua_pop(L, 1);
 
-    if (luaL_loadfile(L, script) || lua_pcall(L, 0, 0, 0))
-        fprintf(stderr, "File: %s could not load: %s\n", script, 
+    if (luaL_loadfile(L, script) || lua_pcall(L, 0, 0, 0)) {
+        fprintf(stderr, "File: %s could not load: %s\n", script,
                 lua_tostring(L, -1));
+        goto exit;
+    }
 
     lead_actors_do_action(L, LOAD);
     
     interp = interpreter_create(L, &is_running);
     while (is_running) {
-        lead_actors_do_action(L, RECEIVE);
+        //lead_actors_do_action(L, RECEIVE);
 
         if (interpreter_poll(interp))
             interpreter_lua_interpret(interp, L);
     }
-    lua_close(L);
 
+exit:
+    lua_close(L);
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -21,7 +21,7 @@ usage (const char *program)
 }
 
 void
-lead_actors_do_action (lua_State *L, Action action)
+lead_actors_receive_update (lua_State *L)
 {
     Actor *actor;
     int table_index = actor_lead_table(L);
@@ -29,18 +29,14 @@ lead_actors_do_action (lua_State *L, Action action)
     lua_pushnil(L);
     while (lua_next(L, table_index)) {
         actor = lua_check_actor(L, -1);
-        actor_call_action(actor, action);
+        actor_call_action(actor, RECEIVE);
 
-        if (action == RECEIVE) {
-            utils_push_objref_method(L, actor->ref, "send");
-            lua_newtable(L);
-            lua_pushstring(L, "main");
-            lua_rawseti(L, -2, 1);
-            lua_call(L, 2, 0);
-            lua_pop(L, 1);
-        }
-
-        lua_pop(L, 1);
+        utils_push_objref_method(L, actor->ref, "send");
+        lua_newtable(L);
+        lua_pushstring(L, "main");
+        lua_rawseti(L, -2, 1);
+        lua_call(L, 2, 0);
+        lua_pop(L, 2);
     }
     lua_pop(L, 1);
 }
@@ -76,8 +72,7 @@ main (int argc, char **argv)
     
     interp = interpreter_create(L, &is_running);
     while (is_running) {
-        lead_actors_do_action(L, RECEIVE);
-
+        lead_actors_receive_update (L);
         if (interpreter_poll(interp))
             interpreter_lua_interpret(interp, L);
     }

--- a/src/main.c
+++ b/src/main.c
@@ -3,6 +3,7 @@
 #include "dialogue.h"
 #include "actor.h"
 #include "interpreter.h"
+#include "utils.h"
 
 static short int is_running = 1;
 
@@ -29,6 +30,16 @@ lead_actors_do_action (lua_State *L, Action action)
     while (lua_next(L, table_index)) {
         actor = lua_check_actor(L, -1);
         actor_call_action(actor, action);
+
+        if (action == RECEIVE) {
+            utils_push_objref_method(L, actor->ref, "send");
+            lua_newtable(L);
+            lua_pushstring(L, "main");
+            lua_rawseti(L, -2, 1);
+            lua_call(L, 2, 0);
+            lua_pop(L, 1);
+        }
+
         lua_pop(L, 1);
     }
     lua_pop(L, 1);
@@ -67,7 +78,7 @@ main (int argc, char **argv)
     
     interp = interpreter_create(L, &is_running);
     while (is_running) {
-        //lead_actors_do_action(L, RECEIVE);
+        lead_actors_do_action(L, RECEIVE);
 
         if (interpreter_poll(interp))
             interpreter_lua_interpret(interp, L);

--- a/src/main.c
+++ b/src/main.c
@@ -23,10 +23,7 @@ void
 lead_actors_do_action (lua_State *L, Action action)
 {
     Actor *actor;
-    int table_index;
-
-    actor_lead_table(L);
-    table_index = lua_gettop(L);
+    int table_index = actor_lead_table(L);
 
     lua_pushnil(L);
     while (lua_next(L, table_index)) {
@@ -34,6 +31,7 @@ lead_actors_do_action (lua_State *L, Action action)
         actor_call_action(actor, action);
         lua_pop(L, 1);
     }
+    lua_pop(L, 1);
 }
 
 int

--- a/src/main.c
+++ b/src/main.c
@@ -73,8 +73,6 @@ main (int argc, char **argv)
                 lua_tostring(L, -1));
         goto exit;
     }
-
-    lead_actors_do_action(L, LOAD);
     
     interp = interpreter_create(L, &is_running);
     while (is_running) {

--- a/src/script.c
+++ b/src/script.c
@@ -104,7 +104,7 @@ script_load (Script *script)
 
     A = actor_request_state(script->actor);
 
-    if (!script->actor->manual_call) {
+    if (!script->actor->is_lead) {
         if (!pthread_equal(calling_thread, script->actor->thread)) {
             script->error = ERR_NOT_CALLING_THREAD;
             ret = LOAD_BAD_THREAD;
@@ -178,7 +178,7 @@ script_send (Script *script, Actor *author)
     lua_State *A = script->actor->L;
     pthread_t calling_thread = pthread_self();
 
-    if (!script->actor->manual_call) {
+    if (!script->actor->is_lead) {
         if (!pthread_equal(calling_thread, script->actor->thread)) {
             ret = SEND_BAD_THREAD;
             goto exit;

--- a/src/utils.c
+++ b/src/utils.c
@@ -49,6 +49,24 @@ utils_add_method (lua_State *L, int index, lua_CFunction f, const char* field)
 }
 
 /*
+ * Remove the first element in a table at given index and leave it on stack.
+ */
+void
+utils_pop_table_head (lua_State *L, int index)
+{
+    /* remove like queue LIFO */
+    lua_getglobal(L, "table");
+    lua_getfield(L, -1, "remove");
+    lua_pushvalue(L, index);
+    lua_pushinteger(L, 1);
+    lua_call(L, 2, 1);
+
+    /* move the 'table' on top to pop */
+    lua_insert(L, lua_gettop(L) - 1);
+    lua_pop(L, 1);
+}
+
+/*
  * Push the first element of a table at index.
  */
 void

--- a/src/utils.h
+++ b/src/utils.h
@@ -33,6 +33,12 @@ void
 utils_add_method (lua_State *L, int index, lua_CFunction f, const char* field);
 
 /*
+ * Remove the first element in a table at given index and leave it on stack.
+ */
+void
+utils_pop_table_head (lua_State *L, int index);
+
+/*
  * Push the first element of a table at index.
  */
 void

--- a/stage.lua
+++ b/stage.lua
@@ -1,1 +1,6 @@
-actor = Dialogue.Actor.new{ "Lead", {"Graphics", 0, 0} }
+--actor = Dialogue.Actor.new{ "Lead", {"Graphics", 0, 0} }
+
+dialogue = Dialogue.new{ 
+    { "Lead", {"Graphics", 0, 0} },
+    { }
+}

--- a/stage.lua
+++ b/stage.lua
@@ -1,1 +1,4 @@
+--actor = Dialogue.new { { {"Graphics", 0, 0} }, { } }
+--actor:lead()
+
 actor = Dialogue.Actor.new({ {"Graphics", 0, 0} }, true)

--- a/stage.lua
+++ b/stage.lua
@@ -1,5 +1,1 @@
-actor = Dialogue.new { { {"Graphics", 0, 0} }, { } }
-actor:lead()
-
---Graphics = require("Graphics")
---g = Graphics.new(0, 0)
+actor = Dialogue.Actor.new{ "Lead", {"Graphics", 0, 0} }

--- a/stage.lua
+++ b/stage.lua
@@ -1,4 +1,5 @@
---actor = Dialogue.new { { {"Graphics", 0, 0} }, { } }
---actor:lead()
+actor = Dialogue.new { { {"Graphics", 0, 0} }, { } }
+actor:lead()
 
-actor = Dialogue.Actor.new({ {"Graphics", 0, 0} }, true)
+--Graphics = require("Graphics")
+--g = Graphics.new(0, 0)

--- a/stage.lua
+++ b/stage.lua
@@ -1,12 +1,1 @@
-actor = Dialogue.Actor.new{ {"draw", 400, 600} }
-
-os.execute("sleep " .. tonumber(0.5))
---actor:send{"wait_move", 2, 2}
-actor:send{"move", 2, 2}
-
---actor = Dialogue.Actor.new({ {"Graphics", 0, 0} }, true)
---actor:send{"clear"}
---actor:send{"set_color", 128, 128, 128, 255}
---print(actor:scripts()[1]:error())
---actor:send{"draw", 2, 2, 48, 48}
---actor:send{"render"}
+actor = Dialogue.Actor.new({ {"Graphics", 0, 0} }, true)


### PR DESCRIPTION
Cleaning up the interpreter, specifically for Lead Actors. Lead Actors are now loaded on creation like a normal Actor. More than one Lead Actor is allowed. Lead Actors are sent a message 'main' with no arguments every loop.